### PR TITLE
Prevenir de ir ao topo da página

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,18 +409,18 @@
                     <div class="col s12 m12 l12">
                         <nav>
                             <div class="nav-wrapper m-teal">
-                                <a href="#" class="brand-logo">logo</a>
+                                <a href="#!" class="brand-logo">logo</a>
                                 <ul>
-                                    <li><a onclick="return false;" href="#">Normal</a></li>
-                                    <li class="underline"><a onclick="return false;" href="#">Underline</a></li>
-                                    <li class="active"><a onclick="return false;" href="#">ACTIVE!!</a></li>
+                                    <li><a href="#!">Normal</a></li>
+                                    <li class="underline"><a href="#!">Underline</a></li>
+                                    <li class="active"><a href="#!">ACTIVE!!</a></li>
                                     <li class="dropdown">
-                                        <a class="btndrop" onclick="return false;" href="#">Drop Hover</a>
+                                        <a class="btndrop" href="#!">Drop Hover</a>
                                         <ul class="dropdown-content">
-                                            <li><a onclick="return false;" href="#">1</a></li>
-                                            <li><a onclick="return false;" href="#">2</a></li>
-                                            <li><a onclick="return false;" href="#">3</a></li>
-                                            <li><a onclick="return false;" href="#">4</a></li>
+                                            <li><a href="#!">1</a></li>
+                                            <li><a href="#!">2</a></li>
+                                            <li><a href="#!">3</a></li>
+                                            <li><a href="#!">4</a></li>
                                         </ul>
                                     </li>
                                     <li><input type="text" name="search" placeholder="Search..."></li>
@@ -443,21 +443,21 @@
                 </div>
                 <div class="row center">
                     <div class="col s12 m12 l12">
-                        <a onclick="return false;" class="btn" href="#">Buttom</a>
-                        <a onclick="return false;" class="btn btn-disabled" href="#">Buttom</a>
+                        <a class="btn" href="#!">Buttom</a>
+                        <a class="btn btn-disabled" href="#!">Buttom</a>
                     </div>
                     <div class="div  col s12 m12 l12">
-                        <a onclick="return false;" class="btn btn-radios" href="#"><i class="mdi mdi-plus mdi-24px"></i></a>
-                        <a onclick="return false;" class="btn btn-radios btn-disabled" href="#"><i class="mdi mdi-plus mdi-24px"></i></a>
+                        <a class="btn btn-radios" href="#!"><i class="mdi mdi-plus mdi-24px"></i></a>
+                        <a class="btn btn-radios btn-disabled" href="#!"><i class="mdi mdi-plus mdi-24px"></i></a>
                     </div>
                     <div class="div col s12 m12 l12">
                         <ul class="dropdown">
-                            <a onclick="return false;" href="#" class="btn btndrop">Hover</a>
+                            <a href="#!" class="btn btndrop">Hover</a>
                             <ul class="dropdown-content">
-                                <li><a onclick="return false;" href="#">1</a></li>
-                                <li><a onclick="return false;" href="#">2</a></li>
-                                <li><a onclick="return false;" href="#">3</a></li>
-                                <li><a onclick="return false;" href="#">4</a></li>
+                                <li><a href="#!">1</a></li>
+                                <li><a href="#!">2</a></li>
+                                <li><a href="#!">3</a></li>
+                                <li><a href="#!">4</a></li>
                             </ul>
                         </ul>
                     </div>
@@ -477,13 +477,13 @@
                 <div class="row">
                     <div class="center col s12 m12 l12">
                         <div class="pagination">
-                            <a href="#" onclick="return false;" class="pag-item prev"><<</a>
-                            <a href="#" onclick="return false;" class="pag-item active">1</a>
-                            <a href="#" onclick="return false;" class="pag-item">2</a>
-                            <a href="#" onclick="return false;" class="pag-item">3</a>
-                            <a href="#" onclick="return false;" class="pag-item">4</a>
-                            <a href="#" onclick="return false;" class="pag-item">5</a>
-                            <a href="#" onclick="return false;" class="pag-item next">>></a>
+                            <a href="#!" class="pag-item prev"><<</a>
+                            <a href="#!" class="pag-item active">1</a>
+                            <a href="#!" class="pag-item">2</a>
+                            <a href="#!" class="pag-item">3</a>
+                            <a href="#!" class="pag-item">4</a>
+                            <a href="#!" class="pag-item">5</a>
+                            <a href="#!" class="pag-item next">>></a>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -411,16 +411,16 @@
                             <div class="nav-wrapper m-teal">
                                 <a href="#" class="brand-logo">logo</a>
                                 <ul>
-                                    <li><a href="#">Normal</a></li>
-                                    <li class="underline"><a href="#">Underline</a></li>
-                                    <li class="active"><a href="#">ACTIVE!!</a></li>
+                                    <li><a onclick="return false;" href="#">Normal</a></li>
+                                    <li class="underline"><a onclick="return false;" href="#">Underline</a></li>
+                                    <li class="active"><a onclick="return false;" href="#">ACTIVE!!</a></li>
                                     <li class="dropdown">
-                                        <a class="btndrop" href="#">Drop Hover</a>
+                                        <a class="btndrop" onclick="return false;" href="#">Drop Hover</a>
                                         <ul class="dropdown-content">
-                                            <li><a href="#">1</a></li>
-                                            <li><a href="#">2</a></li>
-                                            <li><a href="#">3</a></li>
-                                            <li><a href="#">4</a></li>
+                                            <li><a onclick="return false;" href="#">1</a></li>
+                                            <li><a onclick="return false;" href="#">2</a></li>
+                                            <li><a onclick="return false;" href="#">3</a></li>
+                                            <li><a onclick="return false;" href="#">4</a></li>
                                         </ul>
                                     </li>
                                     <li><input type="text" name="search" placeholder="Search..."></li>
@@ -443,21 +443,21 @@
                 </div>
                 <div class="row center">
                     <div class="col s12 m12 l12">
-                        <a class="btn" href="#">Buttom</a>
-                        <a class="btn btn-disabled" href="#">Buttom</a>
+                        <a onclick="return false;" class="btn" href="#">Buttom</a>
+                        <a onclick="return false;" class="btn btn-disabled" href="#">Buttom</a>
                     </div>
                     <div class="div  col s12 m12 l12">
-                        <a class="btn btn-radios" href="#"><i class="mdi mdi-plus mdi-24px"></i></a>
-                        <a class="btn btn-radios btn-disabled" href="#"><i class="mdi mdi-plus mdi-24px"></i></a>
+                        <a onclick="return false;" class="btn btn-radios" href="#"><i class="mdi mdi-plus mdi-24px"></i></a>
+                        <a onclick="return false;" class="btn btn-radios btn-disabled" href="#"><i class="mdi mdi-plus mdi-24px"></i></a>
                     </div>
                     <div class="div col s12 m12 l12">
                         <ul class="dropdown">
-                            <a href="#" class="btn btndrop">Hover</a>
+                            <a onclick="return false;" href="#" class="btn btndrop">Hover</a>
                             <ul class="dropdown-content">
-                                <li><a href="#">1</a></li>
-                                <li><a href="#">2</a></li>
-                                <li><a href="#">3</a></li>
-                                <li><a href="#">4</a></li>
+                                <li><a onclick="return false;" href="#">1</a></li>
+                                <li><a onclick="return false;" href="#">2</a></li>
+                                <li><a onclick="return false;" href="#">3</a></li>
+                                <li><a onclick="return false;" href="#">4</a></li>
                             </ul>
                         </ul>
                     </div>
@@ -477,13 +477,13 @@
                 <div class="row">
                     <div class="center col s12 m12 l12">
                         <div class="pagination">
-                            <a href="#" class="pag-item prev"><<</a>
-                            <a href="#" class="pag-item active">1</a>
-                            <a href="#" class="pag-item">2</a>
-                            <a href="#" class="pag-item">3</a>
-                            <a href="#" class="pag-item">4</a>
-                            <a href="#" class="pag-item">5</a>
-                            <a href="#" class="pag-item next">>></a>
+                            <a href="#" onclick="return false;" class="pag-item prev"><<</a>
+                            <a href="#" onclick="return false;" class="pag-item active">1</a>
+                            <a href="#" onclick="return false;" class="pag-item">2</a>
+                            <a href="#" onclick="return false;" class="pag-item">3</a>
+                            <a href="#" onclick="return false;" class="pag-item">4</a>
+                            <a href="#" onclick="return false;" class="pag-item">5</a>
+                            <a href="#" onclick="return false;" class="pag-item next">>></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Os botões e a navbar de exemplo estavam levando ao topo da página ao clicar.